### PR TITLE
fix for get_advanced_search_facets

### DIFF
--- a/app/controllers/blacklight_advanced_search/advanced_controller.rb
+++ b/app/controllers/blacklight_advanced_search/advanced_controller.rb
@@ -46,11 +46,11 @@ class BlacklightAdvancedSearch::AdvancedController < CatalogController
     input = HashWithIndifferentAccess.new
     input.merge!( search_context_params )
     
-    input.merge!( :qt => blacklight_config.advanced_search[:qt] || blacklight_config.default_qt , :per_page => 0)
+    input.merge!( :qt => blacklight_config.advanced_search[:qt] || blacklight_config.default_qt || blacklight_config.default_solr_params[:qt], :per_page => 0)
     input.merge!( blacklight_config.advanced_search[:form_solr_parameters] ) if blacklight_config.advanced_search[:form_solr_parameters]
     input[:q] ||= '{!lucene}*:*'
     
     
-    find(input.to_hash)
+    find(input[:qt],input.to_hash)
   end
 end


### PR DESCRIPTION
make get_advanced_search_facets method work with latest version of blacklight. check for default qt in new config location, and pass qt to find method as first parameter to conform to other calls to that method (though it only uses args[1] right now).

for more info on this work, see this thread https://groups.google.com/forum/#!msg/blacklight-development/JX1mX_tjeIU/PJKuQXFOi4gJ .

the find method is in blacklight, in lib/blacklight/solr_helper.rb. Its only parameter is *args, and the method only uses args[1], so the input is never used without this change, and facets and item counts never change.
