### PR TITLE
Use += rather than << to update solr_search_params_logic

### DIFF
--- a/lib/blacklight_advanced_search/controller.rb
+++ b/lib/blacklight_advanced_search/controller.rb
@@ -15,7 +15,7 @@ module BlacklightAdvancedSearch::Controller
     
     
     # Parse app URL params used for adv searches 
-    solr_search_params_logic << :add_advanced_search_to_solr
+    self.solr_search_params_logic += [:add_advanced_search_to_solr]
     
     # Display advanced search constraints properly
     helper BlacklightAdvancedSearch::RenderConstraintsOverride

--- a/lib/blacklight_advanced_search/parse_basic_q.rb
+++ b/lib/blacklight_advanced_search/parse_basic_q.rb
@@ -10,7 +10,7 @@ module BlacklightAdvancedSearch::ParseBasicQ
   extend ActiveSupport::Concern
   
   included do
-    solr_search_params_logic << :add_advanced_parse_q_to_solr
+    self.solr_search_params_logic += [:add_advanced_parse_q_to_solr]
   end
   
   


### PR DESCRIPTION
solr_search_params_logic is an class_attribute and if you use << it can
affect the chain on superclasse rather than the concrete class these
modules are included on
