### PR TITLE
modify helper to behavior for easier override

### DIFF
--- a/app/controllers/blacklight_advanced_search/advanced_controller.rb
+++ b/app/controllers/blacklight_advanced_search/advanced_controller.rb
@@ -1,7 +1,7 @@
 # Need to sub-class CatalogController so we get all other plugins behavior
-# for our own "inside a search context" lookup of facets. 
+# for our own "inside a search context" lookup of facets.
 class BlacklightAdvancedSearch::AdvancedController < CatalogController
-  include AdvancedHelper # so we get the #advanced_search_context method
+  include BlacklightAdvancedSearch::AdvancedHelperBehavior # so we get the #advanced_search_context method
 
 
   def index
@@ -12,7 +12,7 @@ class BlacklightAdvancedSearch::AdvancedController < CatalogController
 
   protected
   def get_advanced_search_facets
-    
+
     search_context_params = {}
     if (advanced_search_context.length > 0 )
       # We have a search context, need to fetch facets from within
@@ -21,23 +21,23 @@ class BlacklightAdvancedSearch::AdvancedController < CatalogController
       adv_keys = blacklight_config.search_fields.keys.map {|k| k.to_sym}
       trimmed_params = params.except *adv_keys
       trimmed_params.delete(:f_inclusive) # adv facets
-      
+
       search_context_params = solr_search_params(trimmed_params)
 
       # Don't want to include the 'q' from basic search in our search
       # context. Kind of hacky becuase solr_search_params insists on
-      # using controller.params, not letting us over-ride. 
+      # using controller.params, not letting us over-ride.
       search_context_params.delete(:q)
       search_context_params.delete("q")
-      
+
       # Also delete any facet-related params, or anything else
       # we want to set ourselves
       search_context_params.delete_if do |k, v|
         k = k.to_s
-        (["facet.limit", "facet.sort", "f", "facets", "facet.fields", "per_page"].include?(k) ||                
+        (["facet.limit", "facet.sort", "f", "facets", "facet.fields", "per_page"].include?(k) ||
           k =~ /f\..+\.facet\.limit/ ||
           k =~ /f\..+\.facet\.sort/
-        )        
+        )
       end
     end
 
@@ -47,14 +47,14 @@ class BlacklightAdvancedSearch::AdvancedController < CatalogController
     input[:per_page] = 0 # force
 
     # force if set
-    input[:qt] = blacklight_config.advanced_search[:qt] if blacklight_config.advanced_search[:qt] 
-    
+    input[:qt] = blacklight_config.advanced_search[:qt] if blacklight_config.advanced_search[:qt]
+
     input.merge!( blacklight_config.advanced_search[:form_solr_parameters] ) if blacklight_config.advanced_search[:form_solr_parameters]
 
     # ensure empty query is all records, to fetch available facets on entire corpus
     input[:q] ||= '{!lucene}*:*'
-    
-    # first arg nil, use default search path. 
+
+    # first arg nil, use default search path.
     find(nil, input.to_hash)
   end
 end

--- a/app/helpers/blacklight_advanced_search/advanced_helper_behavior.rb
+++ b/app/helpers/blacklight_advanced_search/advanced_helper_behavior.rb
@@ -1,5 +1,5 @@
 # Helper methods for the advanced search form
-module AdvancedHelper
+module BlacklightAdvancedSearch::AdvancedHelperBehavior
 
   # Fill in default from existing search, if present
   # -- if you are using same search fields for basic

--- a/app/helpers/blacklight_advanced_search_helper.rb
+++ b/app/helpers/blacklight_advanced_search_helper.rb
@@ -1,0 +1,3 @@
+module BlacklightAdvancedSearchHelper
+  include BlacklightAdvancedSearch::AdvancedHelperBehavior
+end


### PR DESCRIPTION
Modifies helper to act as a behavior. In the same pattern as Blacklight. This allows for a Blacklight application to easily override or extend BL Advanced Search view helpers in the same way BL helpers are overridden.
