### PR TITLE
Pass the configured query_parser to ParsingNesting::Tree.parse...

### DIFF
--- a/lib/blacklight_advanced_search/parsing_nesting_parser.rb
+++ b/lib/blacklight_advanced_search/parsing_nesting_parser.rb
@@ -4,7 +4,7 @@ module BlacklightAdvancedSearch::ParsingNestingParser
   def process_query(params,config)
     queries = []
     keyword_queries.each do |field,query| 
-      queries << ParsingNesting::Tree.parse(query).to_query( local_param_hash(field, config)  )            
+      queries << ParsingNesting::Tree.parse(query, config.advanced_search[:query_parser]).to_query( local_param_hash(field, config) )
     end
     queries.join( ' ' + keyword_op + ' ')
   end


### PR DESCRIPTION
...so edismax works.

See https://github.com/projectblacklight/blacklight_advanced_search/blob/adv-search-config/lib/blacklight_advanced_search/parse_basic_q.rb#L43
