### PR TITLE
Add the add_advanced_parse_q_to_solr method to BlacklightAdvancedSearch::AdvancedSearchBuilder

### DIFF
--- a/lib/blacklight_advanced_search/advanced_search_builder.rb
+++ b/lib/blacklight_advanced_search/advanced_search_builder.rb
@@ -1,5 +1,10 @@
+require 'parslet'
+require 'parsing_nesting/tree'
 module BlacklightAdvancedSearch
   module AdvancedSearchBuilder
+
+    include Blacklight::SearchFields
+
     def is_advanced_search?
       (blacklight_params[:search_field] == self.blacklight_config.advanced_search[:url_key]) || blacklight_params[:f_inclusive]
     end
@@ -25,6 +30,50 @@ module BlacklightAdvancedSearch
           solr_parameters[:defType] = "lucene"        
         end
         
+      end
+    end
+
+    # Different versions of Parslet raise different exception classes,
+    # need to figure out which one exists to rescue
+    @@parslet_failed_exceptions = if defined? Parslet::UnconsumedInput
+      [Parslet::UnconsumedInput]
+    else
+      [Parslet::ParseFailed]
+    end
+    
+    
+    # This method can be included in search_params_logic to have us
+    # parse an ordinary entered :q for AND/OR/NOT and produce appropriate
+    # Solr query.
+    #
+    # Note: For syntactically invalid input, we'll just skip the adv
+    # parse and send it straight to solr same as if advanced_parse_q
+    # were not being used. 
+    def add_advanced_parse_q_to_solr(solr_parameters)
+      unless scope.params[:q].blank?
+        field_def = search_field_def_for_key( scope.params[:search_field]) ||
+          default_search_field
+          
+                
+        # If the individual field has advanced_parse_q suppressed, punt
+        return if field_def[:advanced_parse] == false  
+          
+        solr_direct_params = field_def[:solr_parameters] || {}
+        solr_local_params = field_def[:solr_local_parameters] || {}
+        
+        # See if we can parse it, if we can't, we're going to give up
+        # and just allow basic search, perhaps with a warning.
+        begin
+          adv_search_params = ParsingNesting::Tree.parse(scope.params[:q], blacklight_config.advanced_search[:query_parser]).to_single_query_params( solr_local_params )
+
+          BlacklightAdvancedSearch.deep_merge!(solr_parameters, solr_direct_params)
+          BlacklightAdvancedSearch.deep_merge!(solr_parameters, adv_search_params)        
+        rescue *@@parslet_failed_exceptions => e
+          # do nothing, don't merge our input in, keep basic search
+          # optional TODO, display error message in flash here, but hard to 
+          # display a good one. 
+          return
+        end
       end
     end
   end

--- a/lib/blacklight_advanced_search/parse_basic_q.rb
+++ b/lib/blacklight_advanced_search/parse_basic_q.rb
@@ -11,6 +11,9 @@ require 'parsing_nesting/tree'
 # in your CatalogController
 module BlacklightAdvancedSearch::ParseBasicQ
   extend ActiveSupport::Concern
+  extend Deprecation
+
+  self.deprecation_horizon = 'blacklight_advanced_search 6.0'
 
   include Blacklight::SearchFields
   
@@ -65,5 +68,6 @@ module BlacklightAdvancedSearch::ParseBasicQ
       end
     end
   end
+  deprecation_deprecate add_advanced_parse_q_to_solr: "use AdvancedSearchBuilder.add_advanced_parse_q_to_solr"
 
 end

--- a/spec/lib/advanced_search_builder_spec.rb
+++ b/spec/lib/advanced_search_builder_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe BlacklightAdvancedSearch::AdvancedSearchBuilder do
+
+  describe "#add_advanced_parse_q_to_solr" do
+
+    let(:blacklight_config) do
+      Blacklight::Configuration.new do |config|
+        config.advanced_search = { }
+        config.add_search_field "all_fields"
+        config.add_search_field "special_field" do |field|
+          field.advanced_parse = false
+        end
+      end
+    end
+
+    let!(:obj) do
+      class BACTestClass
+        cattr_accessor :blacklight_config
+        include Blacklight::SearchHelper
+        include BlacklightAdvancedSearch::AdvancedSearchBuilder
+        def initialize blacklight_config
+          self.blacklight_config = blacklight_config
+        end
+      end
+      BACTestClass.new blacklight_config
+    end
+
+    context "with basic functionality" do
+      let(:solr_params) { {} }
+
+      describe "a simple example" do
+        let(:params) { double("params", params: {:q => "one two AND three OR four"} ) }
+        before { allow(obj).to receive(:scope).and_return(params) }
+        it "catches the query" do
+          obj.add_advanced_parse_q_to_solr(solr_params) 
+          expect(solr_params[:defType]).to eq("lucene")
+          # We're not testing succesful parsing here, just that it's doing
+          # something that looks like we expect with subqueries. 
+          expect(solr_params[:q]).to start_with("_query_:")
+        end
+      end
+
+      describe "an unparseable example" do
+        let(:unparseable_q) { "foo bar\'s AND" }
+        let(:params) { double("params", params: {:q => unparseable_q} ) }
+        before { allow(obj).to receive(:scope).and_return(params) }
+        it "passes through" do
+          obj.add_advanced_parse_q_to_solr(solr_params)
+          expect(solr_params[:q]).to eq(unparseable_q)
+        end
+      end
+
+      context "when advanced_parse is false" do
+        let(:params) { double("params", params: { :search_field => "special_field", :q => "one two AND three OR four" } ) }
+        before { allow(obj).to receive(:scope).and_return(params) }
+        it "ignores fields" do
+          obj.add_advanced_parse_q_to_solr(solr_params)
+          expect(solr_params).not_to have_key(:q)
+        end
+      end
+
+    end
+
+  end
+
+end

--- a/spec/parsing_nesting/parse_basic_q_spec.rb
+++ b/spec/parsing_nesting/parse_basic_q_spec.rb
@@ -32,7 +32,7 @@ describe "NestingParser" do
   end
 
   describe "basic functionality" do
-    before do 
+    before do
       @blacklight_config = Blacklight::Configuration.new do |config|
         config.advanced_search = {
 
@@ -50,6 +50,7 @@ describe "NestingParser" do
     end
 
     it "catches a simple example" do
+      expect(Deprecation).to receive(:warn)
       solr_params = {}
       @obj.add_advanced_parse_q_to_solr(solr_params, :q => "one two AND three OR four") 
 
@@ -60,6 +61,7 @@ describe "NestingParser" do
     end
 
     it "passes through an unparseable example" do
+      expect(Deprecation).to receive(:warn)
       solr_params = {}
       unparseable_q = "foo bar\'s AND"
       @obj.add_advanced_parse_q_to_solr(solr_params, :q => unparseable_q)
@@ -68,6 +70,7 @@ describe "NestingParser" do
     end
 
     it "ignores field with advanced_parse=false" do
+      expect(Deprecation).to receive(:warn)
       solr_params = {}
       original_q = "one two AND three OR four"
       @obj.add_advanced_parse_q_to_solr(solr_params, 


### PR DESCRIPTION
This paves the way for Blacklight 6.0 compatibility and gets rid of the deprecation warnings that one would see if they're including ParseBasicQ in their controllers. Using Blacklight's SearchBuilder class, you can define your own search builder, include the AdvancedSearchBuilder module, and then add add_advanced_parse_q_to_solr
to search_params_logic.