### PR TITLE
fix for deprecation warning from Rails 4.2.x

### DIFF
--- a/lib/blacklight_advanced_search/render_constraints_override.rb
+++ b/lib/blacklight_advanced_search/render_constraints_override.rb
@@ -23,7 +23,7 @@ module BlacklightAdvancedSearch::RenderConstraintsOverride
         content << render_constraint_element(
           label, query,
           :remove =>
-            catalog_index_path(remove_advanced_keyword_query(field,my_params))
+            search_action_path(remove_advanced_keyword_query(field, my_params))
         )
       end
       if (advanced_query.keyword_op == "OR" &&
@@ -48,7 +48,7 @@ module BlacklightAdvancedSearch::RenderConstraintsOverride
         label = facet_field_label(field)
         content << render_constraint_element(label,
           safe_join(value_list, " <strong class='text-muted constraint-connector'>OR</strong> ".html_safe),
-          :remove => catalog_index_path( remove_advanced_filter_group(field, my_params) )
+          :remove => search_action_path( remove_advanced_filter_group(field, my_params) )
           )
       end
     end


### PR DESCRIPTION
This gets rid of the following message: "DEPRECATION WARNING: Calling URL helpers with string keys controller, action is deprecated. Use symbols instead."