### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add to your application's Gemfile:
 
 then run 'bundle install'.  Then run:
 
-    rails generate blacklight_advanced_search:install
+    rails generate blacklight_advanced_search
 
 * The 'generate' command will install 'require' statements for the plugin's assets into your application's application.js/application.css asset pipeline files
 * And it can optionally install a localized search form with a link to advanced search. If you've already localized your search form you'll want to do this manually instead. 


### PR DESCRIPTION
The current instructions for installing this plugin refer to a generator that apparently does not exist.  I've changed this to the generator that seems to work in 5.1.x.