### PR TITLE
Run without deprecations, in BL 5.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ then run 'bundle install'.  Then run:
 * The 'generate' command will install 'require' statements for the plugin's assets into your application's application.js/application.css asset pipeline files
 * And it can optionally install a localized search form with a link to advanced search. If you've already localized your search form you'll want to do this manually instead. 
 
-You may want to  `include BlacklightAdvancedSearch::ParseBasicQ` in your CatalogController to enable AND/OR/NOT parsing even in ordinary search, this is not on by default.  
+You may want turn to enable AND/OR/NOT parsing even in ordinary search, this is not on by default.  See "Expression parsing in ordinary search" below. 
 
 ## Accessing
  
@@ -64,7 +64,11 @@ If your application uses a single Solr qt request handler for all its search fie
 
 Turn this feature on by adding to your CatalogController definition:
 
-    include BlacklightAdvancedSearch::ParseBasicQ
+    self.search_params_logic << :add_advanced_parse_q_to_solr
+
+And/or, if you've switched over to configuration in SearchBuilder, then to your ./app/models/search_builder.rb:
+
+    self.default_processor_chain << :add_advanced_parse_q_to_solr
 
 This will intercept queries entered in ordinary Blacklight search interface, and parse them for AND/OR/NOT (and parens), producing appropriate Solr query. This allows single-field boolean expressions to be entered in ordinary search, providing a consistent experience with advanced search. 
 

--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,7 @@ end
   task :fixtures => ['engine_cart:generate'] do
     within_test_app do
       ENV['RAILS_ENV'] ||= 'test'
-      system "rake blacklight:solr:seed"
+      system "rake blacklight:index:seed"
       abort "Error running fixtures" unless $?.success?
     end
   end

--- a/app/controllers/blacklight_advanced_search/advanced_controller.rb
+++ b/app/controllers/blacklight_advanced_search/advanced_controller.rb
@@ -1,8 +1,6 @@
 # Need to sub-class CatalogController so we get all other plugins behavior
 # for our own "inside a search context" lookup of facets. 
 class BlacklightAdvancedSearch::AdvancedController < CatalogController
-  include AdvancedHelper # so we get the #advanced_search_context method
-
 
   def index
     unless request.method==:post
@@ -12,48 +10,14 @@ class BlacklightAdvancedSearch::AdvancedController < CatalogController
 
   protected
   def get_advanced_search_facets
-    
-    search_context_params = {}
-    if (advanced_search_context.length > 0 )
-      # We have a search context, need to fetch facets from within
-      # that context -- but we dont' want to search within any
-      # existing :q or ADVANCED facets, so we remove those params.
-      adv_keys = blacklight_config.search_fields.keys.map {|k| k.to_sym}
-      trimmed_params = params.except *adv_keys
-      trimmed_params.delete(:f_inclusive) # adv facets
-      
-      search_context_params = solr_search_params(trimmed_params)
-
-      # Don't want to include the 'q' from basic search in our search
-      # context. Kind of hacky becuase solr_search_params insists on
-      # using controller.params, not letting us over-ride. 
-      search_context_params.delete(:q)
-      search_context_params.delete("q")
-      
-      # Also delete any facet-related params, or anything else
-      # we want to set ourselves
-      search_context_params.delete_if do |k, v|
-        k = k.to_s
-        (["facet.limit", "facet.sort", "f", "facets", "facet.fields", "per_page"].include?(k) ||                
-          k =~ /f\..+\.facet\.limit/ ||
-          k =~ /f\..+\.facet\.sort/
-        )        
-      end
+    # We want to find the facets available for the current search, but:
+    # * IGNORING current query (add in facets_for_advanced_search_form filter)
+    # * IGNORING current advanced search facets (remove add_advanced_search_to_solr filter)
+    response, _ = search_results(params, search_params_logic) do |search_builder|
+      #search_builder.except(:add_advanced_search_to_solr).append(:facets_for_advanced_search_form)
+      search_builder
     end
 
-    input = HashWithIndifferentAccess.new
-    input.merge!( search_context_params )
-
-    input[:per_page] = 0 # force
-
-    # force if set
-    input[:qt] = blacklight_config.advanced_search[:qt] if blacklight_config.advanced_search[:qt] 
-    
-    input.merge!( blacklight_config.advanced_search[:form_solr_parameters] ) if blacklight_config.advanced_search[:form_solr_parameters]
-
-    # ensure empty query is all records, to fetch available facets on entire corpus
-    input[:q] ||= '{!lucene}*:*'
-    
-    repository.search(input)
+    return response
   end
 end

--- a/app/controllers/blacklight_advanced_search/advanced_controller.rb
+++ b/app/controllers/blacklight_advanced_search/advanced_controller.rb
@@ -14,8 +14,7 @@ class BlacklightAdvancedSearch::AdvancedController < CatalogController
     # * IGNORING current query (add in facets_for_advanced_search_form filter)
     # * IGNORING current advanced search facets (remove add_advanced_search_to_solr filter)
     response, _ = search_results(params, search_params_logic) do |search_builder|
-      #search_builder.except(:add_advanced_search_to_solr).append(:facets_for_advanced_search_form)
-      search_builder
+      search_builder.except(:add_advanced_search_to_solr).append(:facets_for_advanced_search_form)            
     end
 
     return response

--- a/blacklight_advanced_search.gemspec
+++ b/blacklight_advanced_search.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "blacklight", "~> 5.10"
+  s.add_dependency "blacklight", "~> 5.15"
   s.add_dependency "parslet"
 
   s.add_development_dependency "rails"

--- a/lib/blacklight_advanced_search/advanced_search_builder.rb
+++ b/lib/blacklight_advanced_search/advanced_search_builder.rb
@@ -76,5 +76,25 @@ module BlacklightAdvancedSearch
         end
       end
     end
+
+    # A Solr param filter that is NOT included by default in the chain,
+    # but is appended by AdvancedController#index, to do a search
+    # for facets _ignoring_ the current query, we want the facets
+    # as if the current query weren't there. 
+    #
+    # Also adds any solr params set in blacklight_config.advanced_search[:form_solr_parameters]
+    def facets_for_advanced_search_form(solr_p)
+      # ensure empty query is all records, to fetch available facets on entire corpus
+      solr_p["q"]            = '{!lucene}*:*'
+
+      # We only care about facets, we don't need any rows. 
+      solr_p["rows"]         = "0"
+
+      # Anything set in config as a literal
+      if blacklight_config.advanced_search[:form_solr_parameters]
+        solr_p.merge!( blacklight_config.advanced_search[:form_solr_parameters] ) 
+      end
+
+    end
   end
 end

--- a/lib/blacklight_advanced_search/render_constraints_override.rb
+++ b/lib/blacklight_advanced_search/render_constraints_override.rb
@@ -23,7 +23,7 @@ module BlacklightAdvancedSearch::RenderConstraintsOverride
         content << render_constraint_element(
           label, query,
           :remove =>
-            search_action_path(remove_advanced_keyword_query(field, my_params))
+            search_action_path(remove_advanced_keyword_query(field, my_params).except(:controller, :action))
         )
       end
       if (advanced_query.keyword_op == "OR" &&
@@ -48,7 +48,7 @@ module BlacklightAdvancedSearch::RenderConstraintsOverride
         label = facet_field_label(field)
         content << render_constraint_element(label,
           safe_join(value_list, " <strong class='text-muted constraint-connector'>OR</strong> ".html_safe),
-          :remove => search_action_path( remove_advanced_filter_group(field, my_params) )
+          :remove => search_action_path( remove_advanced_filter_group(field, my_params).except(:controller, :action) )
           )
       end
     end

--- a/lib/generators/blacklight_advanced_search/install_generator.rb
+++ b/lib/generators/blacklight_advanced_search/install_generator.rb
@@ -15,7 +15,7 @@ module BlacklightAdvancedSearch
         # Blacklight into local app as custom local override -- but add our link at the end too. 
         source_file = File.read(File.join(Blacklight.root, "app/views/catalog/_search_form.html.erb"))
 
-        new_file_contents = source_file + "\n\n<%= link_to 'More options', advanced_search_path(params), :class=>'advanced_search'%>"
+        new_file_contents = source_file + "\n\n<%= link_to 'More options', advanced_search_path(params.except(:controller, :action)), :class=>'advanced_search'%>"
 
         create_file("app/views/catalog/_search_form.html.erb", new_file_contents)      
       end

--- a/spec/features/blacklight_advanced_search_form_spec.rb
+++ b/spec/features/blacklight_advanced_search_form_spec.rb
@@ -7,7 +7,7 @@ describe "Blacklight Advanced Search Form" do
 
   describe "advanced search form" do
     before do
-      visit '/advanced'
+      visit '/advanced?hypothetical_existing_param=true'
     end
 
     it "should have field and facet blocks" do

--- a/spec/features/blacklight_advanced_search_form_spec.rb
+++ b/spec/features/blacklight_advanced_search_form_spec.rb
@@ -7,7 +7,7 @@ describe "Blacklight Advanced Search Form" do
 
   describe "advanced search form" do
     before do
-      visit '/advanced?hypothetical_existing_param=true'
+      visit '/advanced?hypothetical_existing_param=true&q=ignore+this+existing+query'
     end
 
     it "should have field and facet blocks" do


### PR DESCRIPTION
Previous commits/releases removed some BL 5.12+ deprecation warnings. 

But one code path still called the deprecated `solr_search_params`. 

Refactored to avoid that, using the new BL 5.15 SearchBuilder adjusting methods (so this now requires 5.15, gemspec updated).  In the process, made some really messy code a bit cleaner too, hooray for new features. 

Additional changes related to deprecations:

* Updated README with instructions for the optional parse basic query entry feature, that match current BL non-deprecated. 
* Avoided some deprecation warnings from Rails itself by removing un-needed :action and :controller params from route helper calls. 
* Rake testing setup uses new blacklight:index:seed instead of deprecated blacklight:solr:seed

