### PR TITLE
Lock to engine_cart 0.7

### DIFF
--- a/blacklight_advanced_search.gemspec
+++ b/blacklight_advanced_search.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-rails", "~> 3.0"
   s.add_development_dependency "capybara"
   s.add_development_dependency 'jettywrapper', ">= 1.4.2"
-  s.add_development_dependency 'engine_cart', "~> 0.6"
+  s.add_development_dependency 'engine_cart', "~> 0.7.1"
 end


### PR DESCRIPTION
Master is failing, because engine_cart was updated.