### PR TITLE
Silence deprecation warnings for BL::Configuration

### DIFF
--- a/lib/blacklight_advanced_search/controller.rb
+++ b/lib/blacklight_advanced_search/controller.rb
@@ -1,53 +1,45 @@
 require 'blacklight_advanced_search/parsing_nesting_parser'
 
 # This module gets included into CatalogController, or another SearchHelper
-# includer, to add behavior into search_params_logic. 
+# includer, to add behavior into search_params_logic.
 module BlacklightAdvancedSearch::Controller
   extend ActiveSupport::Concern
 
   included do
-    # default adv config values
-    self.blacklight_config.advanced_search ||= Blacklight::OpenStructWithHashAccess.new
-    #self.blacklight_config.advanced_search[:qt] ||= 'advanced'
-    self.blacklight_config.advanced_search[:url_key] ||= 'advanced'
-    self.blacklight_config.advanced_search[:query_parser] ||= 'dismax'
-    self.blacklight_config.advanced_search[:form_solr_parameters] ||= {}    
-    
-    
-    if self.respond_to? :search_params_logic
-      # Parse app URL params used for adv searches 
+    # default advanced config values
+    blacklight_config.advanced_search ||= Blacklight::OpenStructWithHashAccess.new
+    #blacklight_config.advanced_search[:qt] ||= 'advanced'
+    blacklight_config.advanced_search[:url_key] ||= 'advanced'
+    blacklight_config.advanced_search[:query_parser] ||= 'dismax'
+    blacklight_config.advanced_search[:form_solr_parameters] ||= {}
+
+    if respond_to? :search_params_logic
+      # Parse app URL params used for adv searches
       self.search_params_logic += [:add_advanced_search_to_solr]
     end
 
-    if self.blacklight_config.search_builder_class
-    self.blacklight_config.search_builder_class.send(:include,  
-              BlacklightAdvancedSearch::AdvancedSearchBuilder  
-          ) unless
-          self.blacklight_config.search_builder_class.include?(   
-              BlacklightAdvancedSearch::AdvancedSearchBuilder 
+    # Silence deprecations that occur when this code is executed before blacklight
+    # has generated a SearchBuilder.
+    Deprecation.silence Blacklight::Configuration do
+      unless blacklight_config.search_builder_class.include? BlacklightAdvancedSearch::AdvancedSearchBuilder
+        blacklight_config.search_builder_class.send(:include,
+                BlacklightAdvancedSearch::AdvancedSearchBuilder
             )
+      end
     end
-          
-          
+
     # Display advanced search constraints properly
     helper BlacklightAdvancedSearch::RenderConstraintsOverride
     helper BlacklightAdvancedSearch::CatalogHelperOverride
     helper_method :is_advanced_search?, :advanced_query
   end
-  
+
   def is_advanced_search? req_params = params
-    (req_params[:search_field] == self.blacklight_config.advanced_search[:url_key]) ||
+    (req_params[:search_field] == blacklight_config.advanced_search[:url_key]) ||
     req_params[:f_inclusive]
   end
 
   def advanced_query
-    BlacklightAdvancedSearch::QueryParser.new(params, self.blacklight_config ) if is_advanced_search?  
+    BlacklightAdvancedSearch::QueryParser.new(params, blacklight_config) if is_advanced_search?
   end
-  
 end
-
-  
-
-
-  
-


### PR DESCRIPTION
Prior to this change the following deprecation warning would be
displayed 18 times when running the generators:
```
  DEPRECATION WARNING: Your application is missing the SearchBuilder.
  Have you run `rails generate blacklight:search_builder`? Falling back
  to Blacklight::Solr::SearchBuilder. (called from
  locate_search_builder_class at
  /home/travis/.rvm/gems/ruby-2.2.0/gems/blacklight-5.15.0/lib/blacklight/configuration.rb:227)
```
This is occuring because BlacklightAdvancedSearch is referencing the
search_builder before it is generated.