### PR TITLE
allow users to submit simple keyword with inclusive facets

### DIFF
--- a/spec/lib/advanced_search_builder_spec.rb
+++ b/spec/lib/advanced_search_builder_spec.rb
@@ -1,27 +1,27 @@
 describe BlacklightAdvancedSearch::AdvancedSearchBuilder do
+  let(:url_key) { 'advanced' }
+  let(:blacklight_config) do
+    Blacklight::Configuration.new do |config|
+      config.advanced_search = { url_key: 'advanced' }
+      config.add_search_field "all_fields"
+      config.add_search_field "special_field" do |field|
+        field.advanced_parse = false
+      end
+    end
+  end
+  let!(:obj) do
+    class BACTestClass
+      cattr_accessor :blacklight_config
+      include Blacklight::SearchHelper
+      include BlacklightAdvancedSearch::AdvancedSearchBuilder
+      def initialize(blacklight_config)
+        self.blacklight_config = blacklight_config
+      end
+    end
+    BACTestClass.new blacklight_config
+  end
+
   describe "#add_advanced_parse_q_to_solr" do
-    let(:blacklight_config) do
-      Blacklight::Configuration.new do |config|
-        config.advanced_search = {}
-        config.add_search_field "all_fields"
-        config.add_search_field "special_field" do |field|
-          field.advanced_parse = false
-        end
-      end
-    end
-
-    let!(:obj) do
-      class BACTestClass
-        cattr_accessor :blacklight_config
-        include Blacklight::SearchHelper
-        include BlacklightAdvancedSearch::AdvancedSearchBuilder
-        def initialize(blacklight_config)
-          self.blacklight_config = blacklight_config
-        end
-      end
-      BACTestClass.new blacklight_config
-    end
-
     context "with basic functionality" do
       let(:solr_params) { {} }
 
@@ -54,6 +54,43 @@ describe BlacklightAdvancedSearch::AdvancedSearchBuilder do
           obj.add_advanced_parse_q_to_solr(solr_params)
           expect(solr_params).not_to have_key(:q)
         end
+      end
+    end
+  end
+
+  describe "#add_advanced_search_to_solr" do
+    let(:to_solr) { { q: 'advanced query', fq: 'inclusive facet' } }
+    let(:advanced_query) { double('advanced_query') }
+    let(:solr_params) { { q: 'basic', fq: 'original fq' } }
+    before do
+      allow(advanced_query).to receive(:to_solr).and_return(to_solr)
+      allow(advanced_query).to receive(:keyword_queries).and_return([])
+      allow(BlacklightAdvancedSearch::QueryParser).to receive(:new).and_return(advanced_query)
+      allow(obj).to receive(:blacklight_params).and_return(blacklight_params)
+      obj.add_advanced_search_to_solr(solr_params)
+    end
+
+    context "with advanced search_field param and facet" do
+      let(:blacklight_params) do
+        { f_inclusive: { language_facet: ['English'] }, search_field: url_key }
+      end
+      it 'updates solr_params with advanced q' do
+        expect(solr_params[:q]).to eq('advanced query')
+      end
+      it 'updates solr_params with advanced fq' do
+        expect(solr_params[:fq]).to eq('inclusive facet')
+      end
+    end
+
+    context "with basic search_field param and advanced facet" do
+      let(:blacklight_params) do
+        { f_inclusive: { language_facet: ['English'] }, search_field: 'all_fields' }
+      end
+      it 'solr_params q remains the same' do
+        expect(solr_params[:q]).to eq('basic')
+      end
+      it 'updates solr_params with advanced fq' do
+        expect(solr_params[:fq]).to eq('inclusive facet')
       end
     end
   end


### PR DESCRIPTION
When advanced facet limits are applied (with no advanced query), adding a simple keyword search does nothing to affect the search results. This is because the search query gets overriden by a blank advanced query. This PR adjusts the behavior so that the solr query gets replaced only when an advanced query is submitted. [Example query where simple keyword not factored in results.](https://pulsearch.princeton.edu/catalog?utf8=%E2%9C%93&f1=all_fields&q1=&op2=AND&f2=author&q2=&op3=AND&f3=title&q3=&f_inclusive%5Blanguage_facet%5D%5B%5D=English&f_inclusive%5Badvanced_location_s%5D%5B%5D=Architecture+Library&range%5Bpub_date_start_sort%5D%5Bbegin%5D=&range%5Bpub_date_start_sort%5D%5Bend%5D=&sort=score+desc%2C+pub_date_start_sort+desc%2C+title_sort+asc&search_field=all_fields&q=blahblahblah)
