### PR TITLE
add is_advanced_search? check to #add_advanced_parse_q_to_solr

### DIFF
--- a/lib/blacklight_advanced_search/advanced_search_builder.rb
+++ b/lib/blacklight_advanced_search/advanced_search_builder.rb
@@ -48,7 +48,7 @@ module BlacklightAdvancedSearch
     # parse and send it straight to solr same as if advanced_parse_q
     # were not being used.
     def add_advanced_parse_q_to_solr(solr_parameters)
-      return if blacklight_params[:q].blank? || !blacklight_params[:q].respond_to?(:to_str)
+      return if !is_advanced_search? || blacklight_params[:q].blank? || !blacklight_params[:q].respond_to?(:to_str)
 
       field_def = search_field_def_for_key(blacklight_params[:search_field]) ||
         default_search_field


### PR DESCRIPTION
`#add_advanced_parse_q_to_solr` wasn't making the check to see if the search is an advanced search. This was interfering with an extension we're working on in this repository: https://github.com/upenn-libraries/blacklight_solrplugins

`#add_advanced_search_to_solr` is already making this same check, so this brings the two processor methods in line with one another.
