### PR TITLE
add #facet_field_names_for_advanced_search method

### DIFF
--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -1,5 +1,4 @@
 # Helper methods for the advanced search form
 module AdvancedHelper
   include BlacklightAdvancedSearch::AdvancedHelperBehavior
-
 end

--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -42,6 +42,12 @@ module AdvancedHelper
     end
   end
 
+  def facet_field_names_for_advanced_search
+    @facet_fields_for_advanced_search ||= begin
+      blacklight_config.facet_fields.select { |_k, v| v.include_in_advanced_search || v.include_in_advanced_search.nil? }.values.map(&:field)
+    end
+  end
+
   # Use configured facet partial name for facet or fallback on 'catalog/facet_limit'
   def advanced_search_facet_partial_name(display_facet)
     facet_configuration_for_field(display_facet.name).try(:partial) || "catalog/facet_limit"

--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -1,55 +1,5 @@
 # Helper methods for the advanced search form
 module AdvancedHelper
-  # Fill in default from existing search, if present
-  # -- if you are using same search fields for basic
-  # search and advanced, will even fill in properly if existing
-  # search used basic search on same field present in advanced.
-  def label_tag_default_for(key)
-    if !params[key].blank?
-      return params[key]
-    elsif params["search_field"] == key
-      return params["q"]
-    else
-      return nil
-    end
-  end
+  include BlacklightAdvancedSearch::AdvancedHelperBehavior
 
-  # Is facet value in adv facet search results?
-  def facet_value_checked?(field, value)
-    BlacklightAdvancedSearch::QueryParser.new(params, blacklight_config).filters_include_value?(field, value)
-  end
-
-  def select_menu_for_field_operator
-    options = {
-      t('blacklight_advanced_search.all') => 'AND',
-      t('blacklight_advanced_search.any') => 'OR'
-    }.sort
-
-    select_tag(:op, options_for_select(options, params[:op]), :class => 'input-small')
-  end
-
-  # Current params without fields that will be over-written by adv. search,
-  # or other fields we don't want.
-  def advanced_search_context
-    my_params = params.except :page, :commit, :f_inclusive, :q, :search_field, :op, :action, :index, :sort, :controller, :utf8
-
-    my_params.except! *search_fields_for_advanced_search.map { |_key, field_def| field_def[:key] }
-  end
-
-  def search_fields_for_advanced_search
-    @search_fields_for_advanced_search ||= begin
-      blacklight_config.search_fields.select { |_k, v| v.include_in_advanced_search || v.include_in_advanced_search.nil? }
-    end
-  end
-
-  def facet_field_names_for_advanced_search
-    @facet_fields_for_advanced_search ||= begin
-      blacklight_config.facet_fields.select { |_k, v| v.include_in_advanced_search || v.include_in_advanced_search.nil? }.values.map(&:field)
-    end
-  end
-
-  # Use configured facet partial name for facet or fallback on 'catalog/facet_limit'
-  def advanced_search_facet_partial_name(display_facet)
-    facet_configuration_for_field(display_facet.name).try(:partial) || "catalog/facet_limit"
-  end
 end

--- a/app/helpers/blacklight_advanced_search/advanced_helper_behavior.rb
+++ b/app/helpers/blacklight_advanced_search/advanced_helper_behavior.rb
@@ -1,0 +1,58 @@
+module BlacklightAdvancedSearch
+  module AdvancedHelperBehavior
+
+    # Fill in default from existing search, if present
+    # -- if you are using same search fields for basic
+    # search and advanced, will even fill in properly if existing
+    # search used basic search on same field present in advanced.
+    def label_tag_default_for(key)
+      if !params[key].blank?
+        return params[key]
+      elsif params["search_field"] == key
+        return params["q"]
+      else
+        return nil
+      end
+    end
+
+    # Is facet value in adv facet search results?
+    def facet_value_checked?(field, value)
+      BlacklightAdvancedSearch::QueryParser.new(params, blacklight_config).filters_include_value?(field, value)
+    end
+
+    def select_menu_for_field_operator
+      options = {
+        t('blacklight_advanced_search.all') => 'AND',
+        t('blacklight_advanced_search.any') => 'OR'
+      }.sort
+
+      select_tag(:op, options_for_select(options, params[:op]), :class => 'input-small')
+    end
+
+    # Current params without fields that will be over-written by adv. search,
+    # or other fields we don't want.
+    def advanced_search_context
+      my_params = params.except :page, :commit, :f_inclusive, :q, :search_field, :op, :action, :index, :sort, :controller, :utf8
+
+      my_params.except! *search_fields_for_advanced_search.map { |_key, field_def| field_def[:key] }
+    end
+
+    def search_fields_for_advanced_search
+      @search_fields_for_advanced_search ||= begin
+        blacklight_config.search_fields.select { |_k, v| v.include_in_advanced_search || v.include_in_advanced_search.nil? }
+      end
+    end
+
+    def facet_field_names_for_advanced_search
+      @facet_field_names_for_advanced_search ||= begin
+        blacklight_config.facet_fields.select { |_k, v| v.include_in_advanced_search || v.include_in_advanced_search.nil? }.values.map(&:field)
+      end
+    end
+
+    # Use configured facet partial name for facet or fallback on 'catalog/facet_limit'
+    def advanced_search_facet_partial_name(display_facet)
+      facet_configuration_for_field(display_facet.name).try(:partial) || "catalog/facet_limit"
+    end
+
+  end
+end

--- a/app/helpers/blacklight_advanced_search/advanced_helper_behavior.rb
+++ b/app/helpers/blacklight_advanced_search/advanced_helper_behavior.rb
@@ -1,6 +1,6 @@
 module BlacklightAdvancedSearch
+  # implementation for AdvancedHelper
   module AdvancedHelperBehavior
-
     # Fill in default from existing search, if present
     # -- if you are using same search fields for basic
     # search and advanced, will even fill in properly if existing
@@ -26,7 +26,7 @@ module BlacklightAdvancedSearch
         t('blacklight_advanced_search.any') => 'OR'
       }.sort
 
-      select_tag(:op, options_for_select(options, params[:op]), :class => 'input-small')
+      select_tag(:op, options_for_select(options, params[:op]), class: 'input-small')
     end
 
     # Current params without fields that will be over-written by adv. search,
@@ -34,7 +34,7 @@ module BlacklightAdvancedSearch
     def advanced_search_context
       my_params = params.except :page, :commit, :f_inclusive, :q, :search_field, :op, :action, :index, :sort, :controller, :utf8
 
-      my_params.except! *search_fields_for_advanced_search.map { |_key, field_def| field_def[:key] }
+      my_params.except!(*search_fields_for_advanced_search.map { |_key, field_def| field_def[:key] })
     end
 
     def search_fields_for_advanced_search
@@ -53,6 +53,5 @@ module BlacklightAdvancedSearch
     def advanced_search_facet_partial_name(display_facet)
       facet_configuration_for_field(display_facet.name).try(:partial) || "catalog/facet_limit"
     end
-
   end
 end

--- a/app/views/advanced/_advanced_search_facets.html.erb
+++ b/app/views/advanced/_advanced_search_facets.html.erb
@@ -12,5 +12,5 @@
 %>
 
 <div class="advanced-facet-limits panel-group">
-    <%= render_facet_partials facet_field_names %>
+    <%= render_facet_partials facet_field_names_for_advanced_search %>
 </div>


### PR DESCRIPTION
This makes it possible to exclude facets from the advanced search page. We use this to exclude range facets, because they mess up the advanced search html form. See this issue: https://github.com/projectblacklight/blacklight_range_limit/issues/58
