### PR TITLE
Pin rubocop-rspec to 1.8.0

### DIFF
--- a/blacklight_advanced_search.gemspec
+++ b/blacklight_advanced_search.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'solr_wrapper', "~> 0.14"
   s.add_development_dependency 'engine_cart', "~> 0.10"
   s.add_development_dependency 'rubocop'
-  s.add_development_dependency 'rubocop-rspec'
+  s.add_development_dependency 'rubocop-rspec', '~> 1.8.0'
   s.add_development_dependency 'rsolr'
 end


### PR DESCRIPTION
Newer versions of rubocop-rspec add cops which break the build