### PR TITLE
allow range limit and advanced search to install without conflicts

### DIFF
--- a/blacklight_advanced_search.gemspec
+++ b/blacklight_advanced_search.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "capybara"
   s.add_development_dependency 'solr_wrapper', "~> 0.14"
   s.add_development_dependency 'engine_cart', "~> 0.10"
-  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rubocop', '~> 0.46.0'
   s.add_development_dependency 'rubocop-rspec', '~> 1.8.0'
   s.add_development_dependency 'rsolr'
 end

--- a/lib/generators/blacklight_advanced_search/install_generator.rb
+++ b/lib/generators/blacklight_advanced_search/install_generator.rb
@@ -33,11 +33,25 @@ module BlacklightAdvancedSearch
     end
 
     def install_search_history_controller
-      copy_file "search_history_controller.rb", "app/controllers/search_history_controller.rb"
+      path = 'app/controllers/search_history_controller.rb'
+      if File.exist? path
+        inject_into_file path, after: /include Blacklight::SearchHistory.*$/ do
+          "\n  helper BlacklightAdvancedSearch::RenderConstraintsOverride"
+        end
+      else
+        copy_file 'search_history_controller.rb', path
+      end
     end
 
     def install_saved_searches_controller
-      copy_file "saved_searches_controller.rb", "app/controllers/saved_searches_controller.rb"
+      path = 'app/controllers/saved_searches_controller.rb'
+      if File.exist? path
+        inject_into_file path, after: /include Blacklight::SavedSearches.*$/ do
+          "\n  helper BlacklightAdvancedSearch::RenderConstraintsOverride"
+        end
+      else
+        copy_file 'saved_searches_controller.rb', path
+      end
     end
 
     def inject_routes


### PR DESCRIPTION
This change allows the blacklight_advanced_search plugin to properly install when the application already has an existing search history and saved searches controller, adding the range limit behavior to the controllers rather than overwriting them. The range limit plugin also modifies these controllers so this change makes it easier to install a blacklight application that uses both plugins.

Parallel with https://github.com/projectblacklight/blacklight_range_limit/pull/63

Also pins Rubocop to version 0.46, see #75.