### PR TITLE
Resolve longstanding deep_merge! bug

### DIFF
--- a/lib/blacklight_advanced_search.rb
+++ b/lib/blacklight_advanced_search.rb
@@ -11,40 +11,35 @@ module BlacklightAdvancedSearch
 
   require 'blacklight_advanced_search/version'
   require 'blacklight_advanced_search/engine'
-  
-  # Utility method used in our solr search logic. 
-  # Merges new_hash into source_hash, but will recursively
-  # merge nested arrays and hashes too; also will NOT merge nil
-  # or blank values from new_hash into source_hash, nil or blank values
-  # in new_hash will not overwrite values in source_hash. 
+
+  # Utility method used in our solr search logic.
+  # Like Rails Hash#deep_merge, merges 2 hashes recursively, including nested Arrays and Hashes.
+  # Unlike Rails Hash#deep_merge:
+  # - will NOT merge nil values over existing ones
+  # - will NOT merge (non-FalseClass) blank values
+  # - WILL deduplicate values from arrays after merging them
+  #
+  # @param [Hash|HashWithIndifferentAccess] source_hash
+  # @param [Hash|HashWithIndifferentAccess] new_hash
+  # @return [Hash] the deeply merged hash
+  # @see Rails #deep_merge http://apidock.com/rails/v4.2.1/Hash/deep_merge
+  # @example new_hash = BlacklightAdvancedSearch.deep_merge(h1, h2)
+  def self.deep_merge(source_hash, new_hash)
+    source_hash.deep_merge(new_hash, &method(:merge_conflict_resolution))
+  end
+
+  # this one side-effects the first param
+  # @see #deep_merge
+  # @deprecated use `new_hash = BlacklightAdvancedSearch.deep_merge(h1, h2)` instead
   def self.deep_merge!(source_hash, new_hash)
-    # We used to use built-in source_hash.merge() with a block arg
-    # to customize merge behavior, but that was breaking in some
-    # versions of BL/Rails where source_hash was a kind of HashWithIndifferentAccess,
-    # and hwia is unreliable in some versions of Rails. Oh well. 
-    # https://github.com/projectblacklight/blacklight/issues/827
+    source_hash.deep_merge!(new_hash, &method(:merge_conflict_resolution))
+  end
 
-    new_hash.each_pair do |key, new_value|
-      old = source_hash.fetch(key, nil)
-
-      source_hash[key] =     
-        if new_value.respond_to?(:blank) && new.blank?
-          old        
-        elsif (old.kind_of?(Hash) and new_value.kind_of?(Hash))          
-          deep_merge!(old, new_value)
-          old
-        elsif (old.kind_of?(Array) and new_value.kind_of?(Array))
-          old.concat(new_value).uniq
-        elsif new_value.nil?
-          # Allowing nil values to over-write on merge messes things up.
-          # don't set a nil value if you really want to force blank, set
-          # empty string. 
-          old
-        else
-          new_value
-        end
-    end
-    source_hash
-  end  
-  
+  # the arguments are set by what the Rails Hash.deep_merge supplies the block
+  def self.merge_conflict_resolution(_key, old, new_value)
+    return old if new_value.nil?
+    return old if new_value.respond_to?(:blank?) && new_value.blank? && !new_value.is_a?(FalseClass)
+    return old | new_value if old.is_a?(Array) && new_value.is_a?(Array)
+    new_value
+  end
 end

--- a/spec/lib/deep_merge_spec.rb
+++ b/spec/lib/deep_merge_spec.rb
@@ -1,45 +1,123 @@
 require 'spec_helper'
 
-describe "BlacklightAdvancedSearch#deep_merge!" do
-  before do
-    @ahash = {"a" => "a", "b" => "b", 
-            "array1" => [1,2], "array2" => [3,4],
-            "hash1"  => {"a" => "a", "array" => [1], "b" => "b"},
-            "hash2"  => {"a2" => "a2", "array2" => [12], "b2" => "b2"}
+describe 'BlacklightAdvancedSearch#deep_merge' do
+  let(:hash_X) do
+    {
+      'a' => 'a',
+      'b' => 'b',
+      'array1' => [1, 2],
+      'array2' => [3, 4],
+      'hash1'  => { 'a' => 'a', 'array' => [1], 'b' => 'b' },
+      'hash2'  => { 'a2' => 'a2', 'array2' => [12], 'b2' => 'b2' }
     }
-
-    BlacklightAdvancedSearch.deep_merge!(@ahash, {
-      "a" => "NEW A",
-      "array1" => [3, 4],
-      "hash1"  => {
-        "array" => [2],
-        "b" => "NEW B"
-      },
-      "c" => "NEW C"
-    })
+  end
+  let(:hash_Y) do
+    {
+      'a' => 'NEW A',
+      'c' => 'NEW C',
+      'array1' => [3, 4],
+      'hash1'  => { 'array' => [2], 'b' => 'NEW B' }
+    }
+  end
+  let(:ahash) do
+    BlacklightAdvancedSearch.deep_merge(hash_x, hash_y)
   end
 
+  RSpec.shared_examples 'Mergable Parameters' do # this name referenced below
+    it 'does not modify the param hashes' do
+      dup_x = hash_x.dup
+      dup_y = hash_y.dup
+      expect(ahash).not_to eq hash_x # this was the old behavior
+      expect(dup_x).to eq hash_x
+      expect(dup_y).to eq hash_y
+    end
 
-  it "leaves un-collided content alone" do
-    expect(@ahash["b"]).to eq("b")
-    expect(@ahash["array2"]).to eq([3,4])
-    expect(@ahash["hash2"]).to eq({"a2" => "a2", "array2" => [12], "b2" => "b2"})
+    it 'leaves un-collided content alone' do
+      expect(ahash['b']).to eq('b')
+      expect(ahash['array2']).to eq([3, 4])
+      expect(ahash['hash2']).to eq('a2' => 'a2', 'array2' => [12], 'b2' => 'b2')
+    end
+
+    it 'adds new content' do
+      expect(ahash['c']).to eq('NEW C')
+    end
+
+    it 'merges a hash, recursive like' do
+      expect(ahash['hash1']).to eq('a' => 'a', 'array' => [1, 2], 'b' => 'NEW B')
+    end
+
+    it 'merges boolean values (false)' do
+      expect(BlacklightAdvancedSearch.deep_merge({ a: false }, a: true)).to eq(a: true)
+      expect(BlacklightAdvancedSearch.deep_merge({ a: true }, a: false)).to eq(a: false)
+    end
+
+    it 'does not merge nil values over existing keys' do
+      expect(BlacklightAdvancedSearch.deep_merge({ a: 1 }, a: nil)).to eq(a: 1)
+    end
+
+    it 'does merge nil values when the key is not yet present' do
+      expect(BlacklightAdvancedSearch.deep_merge({}, a: nil)).to eq(a: nil)
+    end
+
+    it 'does not merge empty strings over existing keys' do
+      expect(BlacklightAdvancedSearch.deep_merge({ a: 1 }, a: '')).to eq(a: 1)
+      expect(BlacklightAdvancedSearch.deep_merge({ a: nil }, a: '')).to eq(a: nil)
+    end
+
+    it 'does not merge empty strings when the key is not yet present' do
+      expect(BlacklightAdvancedSearch.deep_merge({}, a: '')).to eq(a: '')
+    end
+
+    context 'Arrays' do
+      it 'merges an array' do
+        expect(ahash['array1']).to eq([1, 2, 3, 4])
+      end
+
+      it 'collapse to uniq values when merging' do
+        expect(BlacklightAdvancedSearch.deep_merge({ a: [1, 1, 2, 1] }, a: [3, 2])).to eq(a: [1, 2, 3])
+      end
+
+      it 'does not collapse to uniq values if not merging' do
+        expect(BlacklightAdvancedSearch.deep_merge({ a: [1, 1, 2, 1] }, a: [])).to eq(a: [1, 1, 2, 1])
+      end
+    end
   end
 
-  it "adds new content" do
-    expect(@ahash["c"]).to eq("NEW C")
+  describe Hash do
+    it_behaves_like 'Mergable Parameters' do
+      let(:hash_x) { hash_X }
+      let(:hash_y) { hash_Y }
+    end
   end
 
-  it "merges an array" do
-    expect(@ahash["array1"]).to eq([1,2,3,4])
+  describe HashWithIndifferentAccess do
+    it_behaves_like 'Mergable Parameters' do
+      let(:hash_x) { hash_X.with_indifferent_access }
+      let(:hash_y) { hash_Y.with_indifferent_access }
+    end
   end
 
-  it "merges a hash, recursive like" do
-    expect(@ahash["hash1"]).to eq({
-      "a" => "a",
-      "array" => [1,2],
-      "b" => "NEW B"
-    })
+  describe 'Mixed Hash and HWIA' do
+    it_behaves_like 'Mergable Parameters' do
+      let(:hash_x) { hash_X }
+      let(:hash_y) { hash_Y.with_indifferent_access }
+    end
+
+    it_behaves_like 'Mergable Parameters' do
+      let(:hash_x) { hash_X.with_indifferent_access }
+      let(:hash_y) { hash_Y }
+    end
+  end
+
+  # from http://apidock.com/rails/v4.2.1/Hash/deep_merge
+  describe 'reference example' do
+    it 'gives the same result as Rails Hash .deep_merge' do
+      h1 = { a: true, b: { c: [1, 2, 3] } }
+      h2 = { a: false, b: { x: [3, 4, 5] } }
+      merged = { a: false, b: { c: [1, 2, 3], x: [3, 4, 5] } }
+      expect(h1.deep_merge(h2)).to eq(merged)
+      expect(BlacklightAdvancedSearch.deep_merge(h1, h2)).to eq(merged)
+    end
   end
     
 end


### PR DESCRIPTION
Fixes #55.

Use mainline Rails `deep_merge` with a block.

Massively more robust testing, including running the deep_merge! tests
with HashWithIndifferentAccess objects to allay concerns about that class'
incompatibility.

Added docs.