### PR TITLE
fix multiple parameters in the URL

### DIFF
--- a/app/views/advanced/_advanced_search_form.html.erb
+++ b/app/views/advanced/_advanced_search_form.html.erb
@@ -7,7 +7,7 @@
 
 <%= form_tag search_catalog_path, :class => 'advanced form-horizontal', :method => :get do  %>
 
-  <%= render_hash_as_hidden_fields(search_state.params_for_search(advanced_search_context)) %>
+  <%= render_hash_as_hidden_fields(advanced_search_context) %>
 
   <div class="input-criteria">
 

--- a/spec/features/blacklight_advanced_search_form_spec.rb
+++ b/spec/features/blacklight_advanced_search_form_spec.rb
@@ -54,4 +54,22 @@ describe "Blacklight Advanced Search Form" do
     visit '/advanced'
     expect(page).to have_selector('input#title')
   end
+
+  describe "prepopulated advanced search form" do
+    before do
+      visit '/advanced?all_fields=&author=&commit=Search&op=AND&search_field=advanced&title=cheese'
+    end
+
+    it "should not create hidden inputs for search fields" do
+      expect(page).not_to have_selector('.advanced input[type="hidden"][name="title"]', visible: false)
+      expect(page).to have_selector('.advanced input[type="text"][name="title"]')
+    end
+
+    it "should not have multiple parameters for a search field" do
+      fill_in "title", :with => "bread"
+      click_on "advanced-search-submit"
+      expect(page.current_url).to match(/bread/)
+      expect(page.current_url).not_to match(/cheese/)
+    end
+  end
 end


### PR DESCRIPTION
This fixes the following bug:

- Go to Advanced search page
- Enter a search term for a field (e.g. title=cheese) and submit
- Click "More Options" to return to Advanced search page, which will be prepopulated
- Change "cheese" to "bread" and submit
- URL query string will have title=cheese&title=bread in it

Oddly, it's the 2nd "correct" param that gets used by the search code, so this doesn't actually result in corrupted behavior, only a confusing incorrect URL.
 
The underlying problem is that while `#advanced_search_state` excludes search fields from the hidden form inputs that are generated, it's wrapped in a call to `search_state.params_for_search` which adds them back in. So I've removed that call.

Note that the 2nd test case I added actually passes even without this fix, because capybara's rack_test driver uses only the text input, instead of using both the hidden and text input, which real browsers do. But I've included the test anyway, for completeness. To see the bug in action in a real browser, you can run through the steps above on the code in this repo: https://github.com/codeforkjeff/advanced_search_bug
