### PR TITLE
Explicitly use defType = lucene when building the adv search form

### DIFF
--- a/lib/blacklight_advanced_search/advanced_search_builder.rb
+++ b/lib/blacklight_advanced_search/advanced_search_builder.rb
@@ -83,7 +83,8 @@ module BlacklightAdvancedSearch
     def facets_for_advanced_search_form(solr_p)
       # ensure empty query is all records, to fetch available facets on entire corpus
       solr_p["q"]            = '{!lucene}*:*'
-
+      # explicitly use lucene defType since we are passing a lucene query above (and appears to be required for solr 7)
+      solr_p["defType"]      = 'lucene'
       # We only care about facets, we don't need any rows.
       solr_p["rows"]         = "0"
 


### PR DESCRIPTION
This appears to be necessary to work under solr 7.