### PR TITLE
Allows bundler to find the latest 7.x release from Blacklight

### DIFF
--- a/blacklight_advanced_search.gemspec
+++ b/blacklight_advanced_search.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'blacklight', '~> 7.0'
+  s.add_dependency 'blacklight', '> 7.0.0.a', '< 8.a'
   s.add_dependency "parslet"
 
   s.add_development_dependency "rails"


### PR DESCRIPTION
With how the dependency is written in `master`, bundler complains:

```
➜  psulib_blacklight git:(#46-Advanced-Search) bundle install
Fetching https://github.com/projectblacklight/blacklight_advanced_search.git
Fetching gem metadata from https://rubygems.org/........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "blacklight":
  In snapshot (Gemfile.lock):
    blacklight (= 7.0.0.rc2)

  In Gemfile:
    blacklight (>= 7.0.0.rc2)

    blacklight-marc (>= 7.0.0.rc1) was resolved to 7.0.0.rc1, which depends on
      blacklight (< 8.a, > 7.0.0.a)

    blacklight_advanced_search was resolved to 7.0.0.alpha, which depends on
      blacklight (~> 7.0)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

I copied how `blacklight-marc` wrote the dependency with `blacklight` in their gemspec.