### PR TITLE
Remove navbar-form class

### DIFF
--- a/lib/generators/blacklight_advanced_search/install_generator.rb
+++ b/lib/generators/blacklight_advanced_search/install_generator.rb
@@ -54,7 +54,7 @@ module BlacklightAdvancedSearch
 
       new_file_contents = source_file + <<-EOF.strip_heredoc
       \n\n
-      <div class="navbar-form">
+      <div>
         <%= link_to 'More options', blacklight_advanced_search_engine.advanced_search_path(search_state.to_h), class: 'advanced_search btn btn-secondary'%>
       </div>
       EOF


### PR DESCRIPTION
Just a heads up. This class has [been removed from Twitter Bootstrap as of 4.0.0](https://github.com/twbs/bootstrap/blob/v4.0.0/docs/4.0/migration.md#navbar). 

> Dropped the .navbar-form class entirely. It's no longer necessary; instead, just use .form-inline and apply margin utilities as necessary.

Kind of weird to have a form class on a `div` with a link in it anyway? 🤷‍♂️