### PR TITLE
Fix  local_params_hash method fails field_def is nil.

### DIFF
--- a/lib/blacklight_advanced_search/parsing_nesting_parser.rb
+++ b/lib/blacklight_advanced_search/parsing_nesting_parser.rb
@@ -8,7 +8,7 @@ module BlacklightAdvancedSearch::ParsingNestingParser
   end
 
   def local_param_hash(key, config)
-    field_def = config.search_fields[key]
+    field_def = config.search_fields[key] || {}
 
     (field_def[:solr_adv_parameters] || field_def[:solr_parameters] || {}).merge(field_def[:solr_local_parameters] || {})
   end

--- a/spec/lib/blacklight_advanced_search/parsing_nesting_parser_spec.rb
+++ b/spec/lib/blacklight_advanced_search/parsing_nesting_parser_spec.rb
@@ -1,0 +1,20 @@
+describe BlacklightAdvancedSearch::ParsingNestingParser, type: :module do
+  let(:blacklight_config) do
+    Blacklight::Configuration.new do |config|
+      config.add_facet_field 'type'
+    end
+  end
+
+  let(:subject) { (Object.new).extend(BlacklightAdvancedSearch::ParsingNestingParser) }
+
+  describe "#local_param_hash" do
+
+    context 'with config[key] being nil' do
+      let(:key) { "foo" }
+
+      it "does not fail do no nil error" do
+        expect { subject.local_param_hash(key, blacklight_config) }.not_to  raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
If `field_def` is `nil` then `field_def[foo]` throws no method `[]` defined for
`nil` error.  This change fixes that issue.