### PR TITLE
Some hygeine so Travis tests can pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
+dist: bionic
+
 notifications:
   email: false
-
-before_install:
-  nvm install 12
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 notifications:
   email: false
 
+before_install:
+  nvm install 12
+
 matrix:
   include:
     - rvm: 2.6.5

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gemspec
 

--- a/spec/lib/blacklight_advanced_search/render_constraints_override_spec.rb
+++ b/spec/lib/blacklight_advanced_search/render_constraints_override_spec.rb
@@ -18,7 +18,8 @@ describe BlacklightAdvancedSearch::RenderConstraintsOverride, type: :helper do
       end
     end
 
-    subject(:rendered) { helper.render_constraints_filters({}) }
+    let (:search_state) { Blacklight::SearchState.new(params, blacklight_config)}
+    subject(:rendered) { helper.render_constraints_filters(search_state) }
 
     context 'with an array of facet params' do
       let(:params) { ActionController::Parameters.new f_inclusive: { 'type' => ['a'] } }


### PR DESCRIPTION
Currently, running the tests on master on Travis for this gem fail with two distinct errors:
1. `ActionView::Template::Error: Autoprefixer doesn’t support Node v8.12.0. Update it.`  - 9 tests fail with this issue.
2. `NoMethodError: undefined method 'search_state_class' for #<ActionView::TestCase::TestController:0x00000000094b15a0>` - 2 tests fail with this issue.

Additionally, there are some warnings about gems being found in multiple sources:
```
Warning: the gem 'bindex' was found in multiple sources.
Installed from: https://rubygems.org/
Also found in:
  * http://rubygems.org/
You should add a source requirement to restrict this gem to your preferred source.
```

This PR fixes those errors by:

1) Updating the TRavis config to use Node 12
2) Updating the render_constraints_override spec to work with  with changes introuced in Blacklight 7.8.0, by commmit https://github.com/projectblacklight/blacklight/commit/c11db267465a63f9ba91798369750466cbac0be7

It eliminates the multiple source gem warnings by updating updating the rubygems url to https.