### PR TITLE
Prune unused code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,15 +27,8 @@ else
   end
 
   case ENV['RAILS_VERSION']
-  when /^5.[12]/, /^6.0/
+  when /^5.2/, /^6.0/
     gem 'sass-rails', '~> 5.0'
-  when /^4.2/
-    gem 'responders', '~> 2.0'
-    gem 'sass-rails', '>= 5.0'
-    gem 'coffee-rails', '~> 4.1.0'
-    gem 'json', '~> 1.8'
-  when /^4.[01]/
-    gem 'sass-rails', '< 5.0'
   end
 end
 # END ENGINE_CART BLOCK


### PR DESCRIPTION
We don't need this code since we don't support these versions of Rails. Github detects json 1.x as a security vulnerability