### PR TITLE
Redirect legacy parameters using #to_unsafe_h because we're dealing with raw params

### DIFF
--- a/lib/blacklight_advanced_search/redirect_legacy_params_filter.rb
+++ b/lib/blacklight_advanced_search/redirect_legacy_params_filter.rb
@@ -40,8 +40,8 @@ module BlacklightAdvancedSearch
       end
 
       if legacy_converted
-        controller.send(:redirect_to, params, :status => :moved_permanently)
+        controller.send(:redirect_to, params.to_unsafe_h, :status => :moved_permanently)
       end
     end
   end
-  end
+end


### PR DESCRIPTION
It might be better to immediately lean on `Blacklight::SearchState` to deal with additional validation + cleanup, but `#search_state` is (currently) a private method on the controller.