### PR TITLE
Allow empty parens in a string to be safely parsed

### DIFF
--- a/lib/parsing_nesting/grammar.rb
+++ b/lib/parsing_nesting/grammar.rb
@@ -30,6 +30,11 @@ module ParsingNesting
         paren_list
     end
 
+    rule :empty_paren do
+      (str('()'))
+    end
+
+
     # Note well: It was tricky to parse the thing we want where you can
     # have a flat list with boolean operators, but where 'OR' takes precedence.
     # eg "A AND B OR C AND C" or "A OR B AND C OR D". Tricky to parse at all,
@@ -59,7 +64,7 @@ module ParsingNesting
     end
 
     rule :token do
-      match['^ ")('].repeat(1).as(:token)
+      (match['^ ")('] | empty_paren ).repeat(1).as(:token)
     end
     rule :phrase do
       match('"') >> match['^"'].repeat(1).as(:phrase) >> match('"')

--- a/spec/parsing_nesting/build_tree_spec.rb
+++ b/spec/parsing_nesting/build_tree_spec.rb
@@ -198,6 +198,29 @@ describe "NestingParser" do
       end
     end
 
+    it "should parse term list with empty parens () " do
+      should_be_list parse("foo () bar") do |list|
+        expect(list.length).to eq(3)
+        expect(list[1].value).to eq('()')
+      end
+    end
+
+    it "should parse term list with leading or trailing empty parens () " do
+      should_be_list parse("() foo ()") do |list|
+        expect(list.length).to eq(3)
+        expect(list[0].value).to eq('()')
+        expect(list[2].value).to eq('()')
+      end
+    end
+
+    it "should parse term list with nested parens ()" do
+      should_be_list parse("(()) foo") do |list|
+        expect(list.length).to eq(2)
+        expect(list[0].value).to eq('()')
+      end
+    end
+
+
     it "should build for a crazy complicated one" do
       should_be_list parse("mark +twain AND huck OR fun OR ((jim AND river) AND (red -dogs))") do |list|
         should_be_term list[0], "mark"

--- a/spec/parsing_nesting/consuming_spec.rb
+++ b/spec/parsing_nesting/consuming_spec.rb
@@ -29,7 +29,8 @@ describe "NestingParser" do
      "NOT (four five)",
      "(one two three) OR (four five) AND six",
      '"foo+bar (baz"',
-     "(foo bar one AND two) AND (three four ten OR twelve)"
+     "(foo bar one AND two) AND (three four ten OR twelve)",
+     "one () two"
     ].each do |query|
       it "should consume<<#{query}>>" do
         expect { @parser.parse(query) }.not_to raise_error


### PR DESCRIPTION
This change allows an empty set of parens, `()`, to be in a string and to be parsed as a token. Prior to this change, and empty set of parens would be parsed as a list with no contents which could not be successfully parsed, but instead results in a error as described in #101.

This change fixes issue #101.

This is originally some work by @bibliotechy in this PR which I merged without rebasing and it had issues that needed to be fixed before it could be merged: #112 