### PR TITLE
BL7 Bug Fix - Resolve double facet filter constraint rendering 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 inherit_from: .rubocop_todo.yml
 require: rubocop-rspec
+require: rubocop-rails
 
 AllCops:
   DisplayCopNames: true

--- a/app/views/blacklight_advanced_search/_facet_limit.html.erb
+++ b/app/views/blacklight_advanced_search/_facet_limit.html.erb
@@ -1,16 +1,3 @@
 <div class="advanced_facet_limit">
-  <div class="inclusive_or card card-body bg-light mb-3">
-    <h5>Any of:</h5>
-    <ul class="list-unstyled facet-values">
-    <% advanced_query.filters[facet_field.key].each do |value| %>
-        <li>
-            <span class="selected"><%= h(value) %></span>
-            <%= link_to(remove_advanced_facet_param(facet_field.key, value, params), :class => "remove") do %>
-                <span class="remove-icon"></span>✖<span class="sr-only">[remove]</span>
-            <% end %>
-        </li>
-    <% end %>
-    </ul>
-  </div>
   <%= render_facet_limit display_facet, :layout => nil, :partial => advanced_search_facet_partial_name(display_facet) %>
 </div>

--- a/blacklight_advanced_search.gemspec
+++ b/blacklight_advanced_search.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'solr_wrapper'
   s.add_development_dependency 'engine_cart', "~> 2.0"
   s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rubocop-rails'
   s.add_development_dependency 'rubocop-rspec'
   s.add_development_dependency 'rsolr'
 end

--- a/lib/blacklight_advanced_search/advanced_search_builder.rb
+++ b/lib/blacklight_advanced_search/advanced_search_builder.rb
@@ -5,6 +5,7 @@ module BlacklightAdvancedSearch
     include Blacklight::SearchFields
 
     def is_advanced_search?
+      return false unless self.blacklight_config.advanced_search[:url_key].present?
       (self.blacklight_config.advanced_search && blacklight_params[:search_field] == self.blacklight_config.advanced_search[:url_key]) || blacklight_params[:f_inclusive]
     end
 

--- a/lib/blacklight_advanced_search/render_constraints_override.rb
+++ b/lib/blacklight_advanced_search/render_constraints_override.rb
@@ -37,24 +37,6 @@ module BlacklightAdvancedSearch::RenderConstraintsOverride
     end
   end
 
-  # Over-ride of Blacklight method, provide advanced constraints if needed,
-  # otherwise call super.
-  def render_constraints_filters(my_params = params)
-    content = super(my_params)
-
-    if advanced_query
-      advanced_query.filters.each_pair do |field, value_list|
-        label = facet_field_label(field)
-        content << render_constraint_element(label,
-          safe_join(Array(value_list), " <strong class='text-muted constraint-connector'>OR</strong> ".html_safe),
-          :remove => search_action_path(remove_advanced_filter_group(field, my_params).except(:controller, :action))
-                                            )
-      end
-    end
-
-    content
-  end
-
   # override of BL method, so our inclusive facet selections
   # are still recgonized for eg highlighting facet with selected
   # values.
@@ -72,14 +54,14 @@ module BlacklightAdvancedSearch::RenderConstraintsOverride
     content = super(my_params)
 
     advanced_query = BlacklightAdvancedSearch::QueryParser.new(my_params, blacklight_config)
-
+    
     unless advanced_query.filters.empty?
       advanced_query.filters.each_pair do |field, values|
         # old-style, may still be in history
         values = values.keys if values.is_a? Hash
-
+    
         label = facet_field_label(field)
-
+    
         content << render_search_to_s_element(
           label,
           values.join(" OR ")
@@ -93,15 +75,15 @@ module BlacklightAdvancedSearch::RenderConstraintsOverride
     content = super(my_params)
 
     advanced_query = BlacklightAdvancedSearch::QueryParser.new(my_params, blacklight_config)
-
+    
     if (advanced_query.keyword_queries.length > 1 &&
         advanced_query.keyword_op == "OR")
       # Need to do something to make the inclusive-or search clear
-
+    
       display_as = advanced_query.keyword_queries.collect do |field, query|
         h(blacklight_config.search_fields[field][:label] + ": " + query)
       end.join(" ; ")
-
+    
       content << render_search_to_s_element("Any of",
         display_as,
         :escape_value => false
@@ -109,8 +91,8 @@ module BlacklightAdvancedSearch::RenderConstraintsOverride
     elsif !advanced_query.keyword_queries.empty?
       advanced_query.keyword_queries.each_pair do |field, query|
         label = blacklight_config.search_fields[field][:label]
-
-        content << render_search_to_s_element(label, query)
+    
+       content << render_search_to_s_element(label, query)
       end
     end
 

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -18,6 +18,7 @@
 
   <!-- solr lib dirs -->
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lib" />
+  <lib dir="${solr.install.dir:../../../..}/modules/analysis-extras/lib" />
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs" />
 
   <dataDir>${solr.data.dir:}</dataDir>

--- a/spec/lib/blacklight_advanced_search/render_constraints_override_spec.rb
+++ b/spec/lib/blacklight_advanced_search/render_constraints_override_spec.rb
@@ -8,32 +8,4 @@ describe BlacklightAdvancedSearch::RenderConstraintsOverride, type: :helper do
   let(:advanced_query) do
     BlacklightAdvancedSearch::QueryParser.new(params, blacklight_config)
   end
-
-  describe "#render_constraints_filters" do
-    before do
-      allow(helper).to receive(:blacklight_config).and_return(blacklight_config)
-      allow(helper).to receive(:advanced_query).and_return(advanced_query)
-      allow(helper).to receive(:search_action_path) do |*args|
-        search_catalog_path(*args)
-      end
-    end
-
-    subject(:rendered) { helper.render_constraints_filters({}) }
-
-    context 'with an array of facet params' do
-      let(:params) { ActionController::Parameters.new f_inclusive: { 'type' => ['a'] } }
-
-      it "renders nothing" do
-        expect(rendered).to have_text 'Remove constraint Type: a'
-      end
-    end
-
-    context 'with scalar facet limit params' do
-      let(:params) { ActionController::Parameters.new f_inclusive: { 'type' => 'a' } }
-
-      it "renders the scalar value" do
-        expect(rendered).to have_text 'Remove constraint Type: a'
-      end
-    end
-  end
 end


### PR DESCRIPTION
Fixes #127

* Removes the render_constraints_filters override method
* Removes the _facet_limit.html.erb code that duplicates facet limits
* Specs run green

### Before
<img width="1260" alt="Screenshot 2023-03-03 at 8 51 05 AM" src="https://user-images.githubusercontent.com/69827/222818520-5752433c-dca7-4246-90fc-42cb382b3bec.png">

### After
<img width="1260" alt="Screenshot 2023-03-03 at 11 27 01 AM" src="https://user-images.githubusercontent.com/69827/222818750-98a222f4-7c7e-432a-94c2-fac5f363f7d0.png">

